### PR TITLE
Llama index 0.6.38.post1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,29 +162,6 @@ typings/
 # Local History for Visual Studio Code
 .history/
 
-
-# Provided default Pycharm Run/Debug Configurations should be tracked by git
-# In case of local modifications made by Pycharm, use update-index command
-# for each changed file, like this:
-# git update-index --assume-unchanged .idea/chat_all_the_docs.iml
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/dictionaries
-
-# Sensitive or high-churn files:
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.xml
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-
 # Gradle:
 .idea/**/gradle.xml
 .idea/**/libraries
@@ -338,3 +315,14 @@ delphic/media/*
 
 ### Models for Question Answering
 cache/*
+
+# https://github.com/cookiecutter/cookiecutter-django/blob/de8759fdbd45ac288b97e050073a5d09f50029db/.gitignore#L211
+# Even though the project might be opened and edited
+# in any of the JetBrains IDEs, it makes no sense whatsoever
+# to 'run' anything within it since any particular cookiecutter
+# is declarative by nature.
+.idea/
+
+### Local configuration files
+/.envs/.local
+/frontend/.frontend

--- a/compose/local/django/celery/worker/start
+++ b/compose/local/django/celery/worker/start
@@ -4,5 +4,5 @@ set -o errexit
 set -o nounset
 
 
-#exec watchfiles celery.__main__.main --args '-A config.celery_app worker -l INFO'
-exec celery -A config.celery_app worker -l INFO
+exec watchfiles --filter python celery.__main__.main --args '-A config.celery_app worker -l INFO'
+#exec celery -A config.celery_app worker -l INFO

--- a/config/api/websockets/queries.py
+++ b/config/api/websockets/queries.py
@@ -39,7 +39,9 @@ class CollectionQueryConsumer(AsyncWebsocketConsumer):
 
             {query_str}
             """
-            response = self.index.query(modified_query_str)
+
+            query_engine = self.index.as_query_engine()
+            response = query_engine.query(modified_query_str)
 
             # Format the response as markdown
             markdown_response = f"## Response\n\n{response}\n\n"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,6 +32,6 @@ channels_redis
 
 # NLP-Related
 # ------------------------------------------------------------------------------
-llama_index==0.5.25  # https://github.com/jerryjliu/llama_index
+llama_index==0.6.38.post1  # https://github.com/jerryjliu/llama_index
 PyPDF2==3.*  # https://pypdf2.readthedocs.io/en/latest/
 docx2txt==0.8


### PR DESCRIPTION
Upgrades llama_index version to 0.6.38.post1, fixes https://github.com/JSv4/Delphic/issues/37

The LlamaIndex layout has changed quite a bit recently. These are some minimal changes to stay compatible. More extensive changes would make Delphic fit better with LlamaIndex's updated structure, if this is of interest to the maintainers.
